### PR TITLE
RKP-1: KeycloakProvider blocks app render on init and never settles on failure

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -144,8 +144,20 @@ jobs:
 
 
 
-      # - name: Bump version
-      #   run: yarn version --prerelease --preid rc
+      # Give this run's tarball a version no other run has used.
+      #
+      # `yarn add <tarball>` caches by name@version, and the yarn cache is restored
+      # across runs by setup-node's `cache: 'yarn'`. release-it only bumps the version
+      # on merge to development, so every feature-branch run used to pack DIFFERENT
+      # contents under the SAME 2.1.0 — and yarn served whichever 2.1.0 it had cached
+      # first, silently testing stale code. A unique version makes that collision
+      # impossible. Not committed or tagged: --no-git-tag-version only edits
+      # package.json in the runner's checkout.
+      - name: Bump version for this run
+        run: |
+          _base=`jq --raw-output .version package.json`
+          yarn version --new-version "${_base}-rc.${{ github.run_number }}.${{ github.run_attempt }}" --no-git-tag-version
+          jq --raw-output .version package.json
 
       - name: Build
         run: yarn build
@@ -157,8 +169,8 @@ jobs:
       - name: Pack
         run: yarn pack
 
-      # thats doesn't work, meaning there are some cases when the test is passed, but when installed from npm raises errors.
-      # TODO: support prereleases,
+      # The demo app installs the packed tarball rather than the sources, because
+      # tests have passed against source and still failed once installed from a package.
       - name: Setup demo app
         run: |
           yarn create react-app demo-app --template typescript > /dev/null 2>&1
@@ -167,8 +179,17 @@ jobs:
           _version=`cat package.json | jq  --raw-output .version`
           _name=`cat package.json | jq  --raw-output .name`
           _package="$(pwd)/${_name}-v${_version}.tgz"
+          test -f "$_package" || { echo "::error::packed tarball not found: $_package"; exit 1; }
           cd demo-app
+          # belt and braces: never let a cached entry for this package satisfy the add
+          yarn cache clean "$_name" > /dev/null 2>&1 || true
           yarn add $_package
+          # Prove the tarball is what got installed. A cache hit would leave an older
+          # version here, and the failure would otherwise surface as a confusing type
+          # error against stale .d.ts forty lines later.
+          _installed=`jq --raw-output .version node_modules/${_name}/package.json`
+          test "$_installed" = "$_version" \
+            || { echo "::error::installed ${_name}@${_installed}, expected ${_version} - a stale copy satisfied the add"; exit 1; }
           yarn build
 
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 # production
 /build
 
+# `yarn pack` output (ci/tests reproduce the CI flow locally)
+*.tgz
+
 # misc
 .DS_Store
 .env.local

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,8 +60,16 @@ referencing it — treat that story as broken/stale, not as a guide to existing 
 (`getInstance()` keeps a single `Keycloak` instance for the lifetime of the page).
 It owns:
 - the actual `keycloak-js` instance and its `.init()` call,
-- three listener arrays (`auth-success`, `auth-error`, `keycloak-ready`) with
-  `on()` / `off()` for subscription.
+- four listener arrays (`auth-success`, `auth-error`, `keycloak-ready`,
+  `init-error`) with `on()` / `off()` for subscription,
+- a settled `initState` (`'initializing' | 'ready' | 'failed'`) readable via
+  `getInitState()` / `isAuthenticated()`, because a subscriber that registers
+  *after* init settled never receives the event and has to read what it missed.
+
+`init-error` fires when `keycloak.init()` **rejects** — an unreachable auth server,
+or a browser that blocks the third-party-cookie probe that keycloak-js awaits before
+`onReady`. That is a settled outcome, not a hang, which is why it is a distinct event
+from `auth-error` (which also fires for an ordinary anonymous `check-sso`).
 
 Because it's a singleton, **the first set of `{ config, initOptions }` passed in
 wins** — calling `getInstance()` again with different config after the first
@@ -69,16 +77,25 @@ call does *not* re-initialize Keycloak. Mounting `<KeycloakProvider>` twice with
 different configs in the same page will silently reuse the first instance.
 
 **`KeycloakProvider` (`KeycloakProvider.tsx`)** — a React component that:
-1. On mount, if `disabled` is true, immediately marks itself "ready" with
+1. On mount, if `disabled` is true, immediately marks itself settled with
    `keycloak: null`, `authenticated: false`, and skips Keycloak entirely.
-2. Otherwise gets the `KeycloakService` singleton, subscribes to its events,
-   and renders `loader` (default: `Loading...`) until either `keycloak-ready`
-   fires or `timeout` ms elapse (default 12000ms / `KEYCLOAK_READY_TIMEOUT_MS`).
-3. Exposes `{ keycloak, authenticated, failed }` via Context using the
-   **React 19 Context-as-Provider shorthand** (`<KeycloakContext value={...}>`,
-   not `<KeycloakContext.Provider value={...}>`). See Gotchas below — this is
-   load-bearing for which React versions actually work.
-4. `useKeycloak()` is just `useContext(KeycloakContext)`.
+2. Otherwise gets the `KeycloakService` singleton, subscribes to its events, and
+   **replays the service's current `initState`** in case init already settled.
+3. **Always renders `children`** — it never withholds the app tree. Consumers gate
+   whatever depends on identity on the `initializing` context value themselves.
+4. Tracks one `status` (`'initializing' | 'ready' | 'failed'`). It settles on
+   `keycloak-ready` *or* on `init-error`; `timeout` (default 12000ms /
+   `KEYCLOAK_READY_TIMEOUT_MS`) is only a backstop for an init that never settles
+   either way, **not** the failure path.
+5. Exposes `{ keycloak, authenticated, initializing, failed, loader }` via Context
+   using the **React 19 Context-as-Provider shorthand** (`<KeycloakContext value={...}>`,
+   not `<KeycloakContext.Provider value={...}>`) — matching the `react: ">=19"` peer range.
+   The value is `useMemo`'d.
+6. `useKeycloak()` is just `useContext(KeycloakContext)`.
+
+`initializing` is load-bearing and deliberately distinct from `!authenticated`: it means
+"we don't know yet whether there is a session", so a consumer that dispatches on role can
+avoid rendering an anonymous tree and remounting it when the token lands.
 
 **Public surface (`src/index.ts`)**: `KeycloakProvider`, `useKeycloak`, and the
 re-exported `KeycloakConfig` / `KeycloakInitOptions` types from `keycloak-js`.
@@ -89,7 +106,9 @@ Nothing else in `src/lib` is intended to be imported directly by consumers.
 ```bash
 yarn install        # install deps (yarn.lock is the lockfile of record, not npm)
 yarn build           # rollup -c → build/index.js (cjs), build/index.es.js (esm), build/index.d.ts
-yarn test            # react-scripts test (Jest) — note: no test/ files currently exist in src/
+yarn test            # react-scripts test (Jest) — watch mode
+CI=true yarn test --watchAll=false                # full suite, once
+CI=true yarn test --watchAll=false -t "<name>"    # one test by name
 yarn storybook       # storybook dev -p 6006
 yarn build-storybook # static storybook build
 yarn release         # release-it — bumps version, tags, pushes, creates GH release, publishes to npm
@@ -157,22 +176,24 @@ keep that in mind if asked to "speed up CI by testing source directly."
   from whatever the missing `Loading` component was.
 - **React 19 Context shorthand**: `KeycloakProvider.tsx` renders
   `<KeycloakContext value={...}>` instead of `<KeycloakContext.Provider value={...}>`.
-  This syntax requires React 19+, but `package.json` `peerDependencies` claims
-  `react: ">=18"`. Consumers on React 18 will break. Flag this if asked to touch
-  either the peer range or the Provider syntax — they're currently inconsistent.
+  This syntax requires React 19+, which `package.json` `peerDependencies`
+  (`react: ">=19"`) now matches — keep the two in step if either is touched.
 - **`KeycloakService` singleton ignores subsequent config.** Re-mounting
   `KeycloakProvider` with new `config`/`initOptions` after first init has no effect
   on the already-created Keycloak instance.
 - **`initOptions` default is unreachable**: `keycloakService.ts` does
   `initOptions ?? { onLoad: 'login-required' }`, but `KeycloakProvider` already
   defaults the prop to `{}` (truthy), so that fallback default never fires in practice.
-- **`src/lib/keycloak-provider/README.md`** usage sample has `keycloak & authenticated`
-  (bitwise AND) where `keycloak && authenticated` was clearly intended — don't
-  copy that snippet verbatim if updating docs.
-- **Effect dependency on `ready`** (`KeycloakProvider.tsx`'s `useEffect` deps
-  include `ready`): since `ready` only flips once and the effect tears down/recreates
-  listeners on every dependency change, be careful about reasoning about re-run
-  semantics here if modifying the effect.
+- **The init effect deps are `[disabled]` on purpose.** `config` / `initOptions` /
+  `timeout` are read through a ref instead, because consumers pass them as inline
+  object literals (that is what both READMEs show) and including them re-ran the
+  effect on every render — tearing down all listeners and arming a fresh timeout
+  each time. Re-running would be pointless anyway: the service singleton ignores
+  config after the first init. Don't "fix" the exhaustive-deps warning by adding
+  them back; the ref is the fix.
+- **`ci/tests/App.tsx` is a real consumer of the public contract.** It gates its
+  auth controls on `initializing`, which is what keeps the Selenium test from
+  clicking `Login` before `keycloak` exists. Update it alongside any context change.
 - **Two READMEs exist** with overlapping but slightly different usage examples:
   root `README.md` and `src/lib/keycloak-provider/README.md`. Keep both in sync
   if changing the public API or prop list.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,18 @@ There's a comment in the workflow noting this approach exists because tests
 sometimes pass against source but fail once installed from a packed tarball —
 keep that in mind if asked to "speed up CI by testing source directly."
 
+**Why the workflow bumps to an `-rc.<run>.<attempt>` version before packing.**
+`yarn add <tarball>` caches by `name@version`, and setup-node's `cache: 'yarn'`
+restores that cache across runs. `release-it` only bumps the version on merge to
+`development`, so without the bump every feature-branch run packs *different*
+contents under the *same* version — and yarn installs whichever copy it cached
+first. The symptom is a demo-app build failing against stale `.d.ts`
+(e.g. `Property 'x' does not exist on type ...` for something the branch just
+added), which looks like a source bug and isn't. The `Setup demo app` step
+asserts the installed version equals the packed one, so a recurrence fails
+immediately with a clear message instead. Don't remove the bump to "keep the
+version clean" — nothing is committed or tagged (`--no-git-tag-version`).
+
 ## Release process
 
 - Work happens on branches named `feature/*` or `hotfix/*`, PR'd into `development`.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,22 @@
 
 Based on `keycloak-js` package, wraps it with React Context Provider
 
+> **Changed in 2.2.0 — the provider no longer withholds your app while Keycloak initializes.**
+> Earlier versions rendered `loader` *instead of* `children` until init finished or
+> `timeout` elapsed, so nothing rendered — public routes included — during a slow or
+> failing init. `children` now render immediately and you decide what to gate, using the
+> new `initializing` context value. If you were relying on the old global gate, reproduce
+> it in one line at the top of your app:
+>
+> ```tsx
+> const { initializing, loader } = useKeycloak();
+> if (initializing) return <>{loader}</>;
+> ```
+>
+> The provider also settles as soon as `keycloak.init()` rejects (unreachable server, or a
+> browser that blocks the third-party-cookie probe) instead of waiting out the full
+> `timeout` — `timeout` is now only a backstop for an init that hangs.
+
 ##### usage
 ```tsx
 
@@ -19,8 +35,12 @@ root.render(
   <React.StrictMode>
     <KeycloakProvider
       disabled={false}              // optional - (default = false) disable keycloak auth ("keycloak" instance returned from hook would be null)
-      timeout={12000}               // optional - connection timeout (default = 12000)
-      loader={<MyCustomProgress />} // optional - custom loader  (default = <>Loading</>)
+      timeout={12000}               // optional - backstop for an init that never settles
+                                    // (default = 12000). Not the failure path: a rejected
+                                    // init settles immediately.
+      loader={<MyCustomProgress />} // optional - handed back through the hook so you can
+                                    // gate your own subtree on `initializing`
+                                    // (default = <>Loading...</>). No longer applied globally.
 
       // passed to constructor
       // const keycloak = new Keycloak({ ... })  
@@ -52,7 +72,13 @@ import { useKeycloak } from 'react-keycloak-provider';
 import Button from '@mui/material/Button';
 
 const AppBar = ()=> {
-    const {keycloak, authenticated} = useKeycloak();
+    const {keycloak, authenticated, initializing, loader} = useKeycloak();
+
+    // `initializing` means "we don't know yet whether there is a session" —
+    // it is not the same as "anonymous". Gate on it so you don't render the
+    // signed-out UI first and swap it out when the token lands.
+    if (initializing) return <>{loader}</>;
+
     return (
         <div> 
             {keycloak && authenticated? 
@@ -64,6 +90,16 @@ const AppBar = ()=> {
 
 };
 ```
+
+##### what `useKeycloak()` returns
+
+| field | type | meaning |
+| --- | --- | --- |
+| `keycloak` | `Keycloak \| null` | the adapter instance; `null` while initializing, when `disabled`, and when init failed |
+| `authenticated` | `boolean` | there is a session. Only meaningful once `initializing` is false |
+| `initializing` | `boolean` | `keycloak.init()` is still in flight. False in **both** settled outcomes |
+| `failed` | `boolean` | init rejected, or the `timeout` backstop fired |
+| `loader` | `React.ReactNode` | the provider's `loader` prop, for gating your own subtree |
 
 
 ```html

--- a/ci/tests/App.tsx
+++ b/ci/tests/App.tsx
@@ -4,9 +4,27 @@ import './App.css';
 import { useKeycloak } from 'react-keycloak-provider'
 
 function App() {
-  const { keycloak, authenticated } = useKeycloak();
+  const { keycloak, authenticated, initializing, loader } = useKeycloak();
 
-
+  // children now render while init is still in flight, so only the part that
+  // actually depends on the session waits for it.
+  const authControls = initializing ? loader : (
+    authenticated ?
+      <a
+        className="App-link"
+        href="#"
+        onClick={() => keycloak?.logout()}
+      >
+        Logout
+      </a> :
+      <a
+        className="App-link"
+        href="#"
+        onClick={() => keycloak?.login()}
+      >
+        Login
+      </a>
+  );
 
   return (
     <div className="App">
@@ -15,22 +33,7 @@ function App() {
         <p>
           Edit <code>src/App.tsx</code> and save to reload.
         </p>
-        {authenticated ?
-         <a
-          className="App-link"
-          href="#"
-          onClick={() => keycloak.logout()}
-        >
-          Logout
-        </a> :
-          <a
-            className="App-link"
-            href="#"
-            onClick={() => keycloak.login()}
-          >
-            Login
-          </a>
-        }
+        {authControls}
       </header>
     </div>
   );

--- a/src/lib/keycloak-provider/KeycloakProvider.test.tsx
+++ b/src/lib/keycloak-provider/KeycloakProvider.test.tsx
@@ -85,8 +85,9 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  consoleError.mockRestore();
-  consoleWarn.mockRestore();
+  // restoreAllMocks, not per-spy mockRestore: a failing assertion must not leak
+  // a spy (console, or KeycloakService.prototype) into the tests that follow.
+  jest.restoreAllMocks();
 });
 
 test('renders children immediately while init is still in flight', () => {
@@ -171,9 +172,6 @@ test('the init effect runs once per mount when initOptions is an inline object l
   // four events subscribed, exactly once — no teardown/re-arm on the re-renders
   expect(onSpy).toHaveBeenCalledTimes(4);
   expect(offSpy).not.toHaveBeenCalled();
-
-  onSpy.mockRestore();
-  offSpy.mockRestore();
 });
 
 test('a provider mounted after init already settled picks up the settled state', async () => {
@@ -200,6 +198,38 @@ test('disabled skips Keycloak entirely and never gates children', () => {
   expect(text('failed')).toBe('false');
   expect(text('keycloak')).toBe('null');
   expect(mockAdapter.instances).toHaveLength(0);
+});
+
+test('re-enabling a disabled provider reports initializing again', () => {
+  const tree = (disabled: boolean) => (
+    <KeycloakProvider
+      config={{ url: 'http://localhost:8282/', realm: 'demo', clientId: 'react-client' }}
+      initOptions={{ onLoad: 'check-sso' }}
+      timeout={100000}
+      disabled={disabled}
+    >
+      <Probe />
+    </KeycloakProvider>
+  );
+
+  const { rerender } = render(tree(true));
+  expect(text('initializing')).toBe('false');
+
+  // init is genuinely in flight now, so "settled anonymous" would be a lie
+  rerender(tree(false));
+  expect(text('initializing')).toBe('true');
+  expect(text('authenticated')).toBe('false');
+  expect(text('failed')).toBe('false');
+});
+
+test('settles even when the adapter resolves init without ever calling onReady', async () => {
+  mockAdapter.init = () => Promise.resolve(false);
+
+  renderProvider();
+
+  await waitFor(() => expect(text('initializing')).toBe('false'));
+  expect(text('failed')).toBe('false');
+  expect(text('keycloak')).toBe('instance');
 });
 
 test('an init that rejects long after mount still settles the provider', async () => {

--- a/src/lib/keycloak-provider/KeycloakProvider.test.tsx
+++ b/src/lib/keycloak-provider/KeycloakProvider.test.tsx
@@ -1,0 +1,218 @@
+import * as React from 'react';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import { KeycloakProvider, useKeycloak } from './KeycloakProvider';
+import { KeycloakService } from './keycloakService';
+
+/**
+ * A stand-in for the keycloak-js adapter whose `init()` outcome each test drives.
+ * `mock`-prefixed so jest's hoisted factory is allowed to reference it.
+ */
+const mockAdapter: {
+  instances: MockKeycloak[];
+  init: (kc: MockKeycloak) => Promise<boolean>;
+} = {
+  instances: [],
+  init: () => new Promise<boolean>(() => {}), // never settles unless a test says otherwise
+};
+
+interface MockKeycloak {
+  onReady?: (authenticated?: boolean) => void;
+  init: () => Promise<boolean>;
+}
+
+jest.mock('keycloak-js', () => ({
+  __esModule: true,
+  default: class {
+    onReady?: (authenticated?: boolean) => void;
+
+    constructor() {
+      mockAdapter.instances.push(this as unknown as MockKeycloak);
+    }
+
+    init() {
+      return mockAdapter.init(this as unknown as MockKeycloak);
+    }
+  },
+}));
+
+/** Resolves after init(), mimicking keycloak-js calling onReady just before it resolves. */
+const initResolves = (authenticated: boolean) => (kc: MockKeycloak) => {
+  kc.onReady?.(authenticated);
+  return Promise.resolve(authenticated);
+};
+
+/** Rejects the way init() does when the 3rd-party-cookie probe cannot complete. */
+const initRejects = () => () =>
+  Promise.reject(new Error('Timeout when waiting for 3rd party check iframe message.'));
+
+const Probe = () => {
+  const { keycloak, authenticated, initializing, failed, loader } = useKeycloak();
+  return (
+    <div>
+      <span data-testid="app">app</span>
+      <span data-testid="initializing">{String(initializing)}</span>
+      <span data-testid="authenticated">{String(authenticated)}</span>
+      <span data-testid="failed">{String(failed)}</span>
+      <span data-testid="keycloak">{keycloak ? 'instance' : 'null'}</span>
+      {initializing ? <span data-testid="gate">{loader}</span> : null}
+    </div>
+  );
+};
+
+const renderProvider = (props: Partial<React.ComponentProps<typeof KeycloakProvider>> = {}) =>
+  render(
+    <KeycloakProvider
+      config={{ url: 'http://localhost:8282/', realm: 'demo', clientId: 'react-client' }}
+      initOptions={{ onLoad: 'check-sso' }}
+      timeout={100000}
+      {...props}
+    >
+      <Probe />
+    </KeycloakProvider>
+  );
+
+const text = (testId: string) => screen.getByTestId(testId).textContent;
+
+let consoleError: jest.SpyInstance;
+let consoleWarn: jest.SpyInstance;
+
+beforeEach(() => {
+  KeycloakService.resetInstance();
+  mockAdapter.instances = [];
+  mockAdapter.init = () => new Promise<boolean>(() => {});
+  consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+  consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  consoleError.mockRestore();
+  consoleWarn.mockRestore();
+});
+
+test('renders children immediately while init is still in flight', () => {
+  renderProvider();
+
+  expect(text('app')).toBe('app');
+  expect(text('initializing')).toBe('true');
+  expect(text('authenticated')).toBe('false');
+  expect(text('failed')).toBe('false');
+  expect(text('keycloak')).toBe('null');
+});
+
+test('exposes the loader prop so a consumer can gate its own subtree', () => {
+  renderProvider({ loader: <>custom loading</> });
+
+  expect(screen.getByTestId('gate').textContent).toBe('custom loading');
+});
+
+test('settles as failed when init rejects, without waiting out the timeout', async () => {
+  mockAdapter.init = initRejects();
+
+  // timeout is 100s: only the rejection path can settle this within the test.
+  renderProvider();
+
+  await waitFor(() => expect(text('failed')).toBe('true'));
+  expect(text('initializing')).toBe('false');
+  expect(text('authenticated')).toBe('false');
+  expect(text('app')).toBe('app');
+  expect(consoleWarn).not.toHaveBeenCalled();
+});
+
+test('reports an authenticated session on the success path', async () => {
+  mockAdapter.init = initResolves(true);
+
+  renderProvider();
+
+  await waitFor(() => expect(text('authenticated')).toBe('true'));
+  expect(text('initializing')).toBe('false');
+  expect(text('failed')).toBe('false');
+  expect(text('keycloak')).toBe('instance');
+});
+
+test('a settled anonymous check-sso is not a failure', async () => {
+  mockAdapter.init = initResolves(false);
+
+  renderProvider();
+
+  await waitFor(() => expect(text('initializing')).toBe('false'));
+  expect(text('authenticated')).toBe('false');
+  expect(text('failed')).toBe('false');
+  expect(text('keycloak')).toBe('instance');
+});
+
+test('the timeout backstop still settles an init that never resolves or rejects', async () => {
+  renderProvider({ timeout: 50 });
+
+  expect(text('initializing')).toBe('true');
+  await waitFor(() => expect(text('failed')).toBe('true'));
+  expect(text('initializing')).toBe('false');
+  expect(consoleWarn).toHaveBeenCalled();
+});
+
+test('the init effect runs once per mount when initOptions is an inline object literal', () => {
+  const onSpy = jest.spyOn(KeycloakService.prototype, 'on');
+  const offSpy = jest.spyOn(KeycloakService.prototype, 'off');
+
+  // fresh `config` / `initOptions` references on every render, as a consumer writes it
+  const tree = () => (
+    <KeycloakProvider
+      config={{ url: 'http://localhost:8282/', realm: 'demo', clientId: 'react-client' }}
+      initOptions={{ onLoad: 'check-sso' }}
+      timeout={100000}
+    >
+      <Probe />
+    </KeycloakProvider>
+  );
+
+  const { rerender } = render(tree());
+  rerender(tree());
+  rerender(tree());
+
+  // four events subscribed, exactly once — no teardown/re-arm on the re-renders
+  expect(onSpy).toHaveBeenCalledTimes(4);
+  expect(offSpy).not.toHaveBeenCalled();
+
+  onSpy.mockRestore();
+  offSpy.mockRestore();
+});
+
+test('a provider mounted after init already settled picks up the settled state', async () => {
+  mockAdapter.init = initResolves(true);
+
+  const first = renderProvider();
+  await waitFor(() => expect(text('authenticated')).toBe('true'));
+  first.unmount();
+
+  // The singleton has already fired 'keycloak-ready'; a fresh mount must not hang.
+  renderProvider();
+
+  expect(text('initializing')).toBe('false');
+  expect(text('authenticated')).toBe('true');
+  expect(text('keycloak')).toBe('instance');
+});
+
+test('disabled skips Keycloak entirely and never gates children', () => {
+  renderProvider({ disabled: true });
+
+  expect(text('app')).toBe('app');
+  expect(text('initializing')).toBe('false');
+  expect(text('authenticated')).toBe('false');
+  expect(text('failed')).toBe('false');
+  expect(text('keycloak')).toBe('null');
+  expect(mockAdapter.instances).toHaveLength(0);
+});
+
+test('an init that rejects long after mount still settles the provider', async () => {
+  let rejectInit: (error: Error) => void = () => {};
+  mockAdapter.init = () => new Promise<boolean>((_resolve, reject) => { rejectInit = reject; });
+
+  renderProvider();
+  expect(text('initializing')).toBe('true');
+
+  await act(async () => {
+    rejectInit(new Error('Timeout when waiting for 3rd party check iframe message.'));
+  });
+
+  expect(text('initializing')).toBe('false');
+  expect(text('failed')).toBe('true');
+});

--- a/src/lib/keycloak-provider/KeycloakProvider.tsx
+++ b/src/lib/keycloak-provider/KeycloakProvider.tsx
@@ -1,5 +1,5 @@
 // KeycloakProvider.tsx
-import React, { createContext, useContext, useState, useEffect } from 'react';
+import React, { createContext, useContext, useState, useEffect, useMemo, useRef } from 'react';
 import type { KeycloakConfig, KeycloakInitOptions } from 'keycloak-js';
 import Keycloak from 'keycloak-js';
 import { KeycloakService } from './keycloakService';
@@ -8,7 +8,18 @@ import { KeycloakService } from './keycloakService';
 interface KeycloakContextType {
   keycloak: Keycloak | null;
   authenticated: boolean;
-  failed?: boolean; // true if server offline / timeout
+  /**
+   * true while `keycloak.init()` is still in flight — i.e. whether there is a
+   * session is not known yet. false in both settled outcomes, so it is never a
+   * synonym for "anonymous". Gate role-dependent UI on this, not on
+   * `authenticated`, to avoid rendering an anonymous tree and remounting it
+   * when the token lands.
+   */
+  initializing: boolean;
+  /** true if init rejected (server offline / blocked 3rd-party cookies) or the timeout backstop fired */
+  failed?: boolean;
+  /** the provider's `loader` prop, so a consumer can gate its own subtree on `initializing` */
+  loader?: React.ReactNode;
 }
 
 interface KeycloakProviderProps {
@@ -16,16 +27,22 @@ interface KeycloakProviderProps {
   initOptions?: KeycloakInitOptions;
   children: React.ReactNode;
   disabled?: boolean; // new prop
-  timeout?: number; 
+  timeout?: number;
   loader?:React.ReactNode;
 }
 
 // Timeout in milliseconds for Keycloak server to respond
 const KEYCLOAK_READY_TIMEOUT_MS = 12000;
 
+// Module-level so the default does not change identity on every render
+const DEFAULT_LOADER = <>Loading...</>;
+
+type InitStatus = 'initializing' | 'ready' | 'failed';
+
 const KeycloakContext = createContext<KeycloakContextType>({
   keycloak: null,
   authenticated: false,
+  initializing: false,
   failed: false,
 });
 
@@ -39,32 +56,42 @@ export const KeycloakProvider = ({
   children,
    disabled = false,
    timeout = KEYCLOAK_READY_TIMEOUT_MS,
-   loader =  <>Loading...</>
+   loader = DEFAULT_LOADER
 }: KeycloakProviderProps) => {
   const [keycloak, setKeycloak] = useState<Keycloak | null>(null);
   const [authenticated, setAuthenticated] = useState(false);
-  const [ready, setReady] = useState(false);
-  const [timedOut, setTimedOut] = useState(false);
+  const [status, setStatus] = useState<InitStatus>(disabled ? 'ready' : 'initializing');
 
+  // Consumers pass `config` / `initOptions` as inline object literals (that is what
+  // the README shows), so they are fresh references on every render. Reading them
+  // through a ref keeps the init effect from tearing down its listeners and arming
+  // a new timeout on each one, without asking consumers to memoize anything.
+  const propsRef = useRef({ config, initOptions, timeout });
+  propsRef.current = { config, initOptions, timeout };
 
-  
   useEffect(() => {
     if (disabled) {
-      // If disabled, consider ready immediately and skip initialization
-      setReady(true);
+      // If disabled, consider it settled immediately and skip initialization
+      setKeycloak(null);
       setAuthenticated(false);
-      setTimedOut(false);
+      setStatus('ready');
       return;
     }
 
+    const { config, initOptions, timeout } = propsRef.current;
     const keycloakService = KeycloakService.getInstance({ config, initOptions });
 
+    let settled = false;
+
     const onReady = () => {
-      const instance = keycloakService.getKeycloakInstance();
-      if (instance) {
-        setKeycloak(instance);
-        setReady(true);
-      }
+      settled = true;
+      setKeycloak(keycloakService.getKeycloakInstance());
+      setStatus('ready');
+    };
+
+    const onInitError = () => {
+      settled = true;
+      setStatus('failed');
     };
 
     const onAuthSuccess = () => setAuthenticated(true);
@@ -72,40 +99,52 @@ export const KeycloakProvider = ({
 
     // Register listeners
     keycloakService.on('keycloak-ready', onReady);
+    keycloakService.on('init-error', onInitError);
     keycloakService.on('auth-success', onAuthSuccess);
     keycloakService.on('auth-error', onAuthError);
 
-    // Timeout fallback in case server is offline
+    // The service is a page-lifetime singleton, so init may already have settled
+    // before this provider mounted (a remount, StrictMode's second pass, a second
+    // provider). Those listeners will never fire — replay what was missed.
+    const initState = keycloakService.getInitState();
+    if (initState === 'ready') {
+      setAuthenticated(keycloakService.isAuthenticated());
+      onReady();
+    } else if (initState === 'failed') {
+      setAuthenticated(false);
+      onInitError();
+    }
+
+    // Backstop for an init that never settles either way. The failure path is
+    // handled by 'init-error' above, so this should only fire on a genuine hang.
     const _timeout = setTimeout(() => {
-      if (!ready) {
-        console.warn('KeycloakService did not become ready within timeout');
-        setTimedOut(true);
-      }
+      if (settled) return;
+      console.warn('KeycloakService did not become ready within timeout');
+      setStatus('failed');
     }, timeout);
 
     // Cleanup on unmount
     return () => {
       clearTimeout(_timeout);
       keycloakService.off('keycloak-ready', onReady);
+      keycloakService.off('init-error', onInitError);
       keycloakService.off('auth-success', onAuthSuccess);
       keycloakService.off('auth-error', onAuthError);
     };
-  }, [config, initOptions, ready]);
+  }, [disabled]);
 
-  // Show loading until ready or timed out
-  if (!ready && !timedOut) {
-    return <>{loader}</>;
-  }
+  const value = useMemo<KeycloakContextType>(() => ({
+    keycloak: disabled ? null : keycloak,
+    authenticated: disabled ? false : authenticated,
+    initializing: disabled ? false : status === 'initializing',
+    failed: disabled ? false : status === 'failed',
+    loader,
+  }), [disabled, keycloak, authenticated, status, loader]);
 
-  // Provide safe context even if server is offline
+  // children render immediately — including while init is in flight. Consumers
+  // gate whatever actually depends on identity on `initializing`.
   return (
-    <KeycloakContext value={{
-
-      keycloak: disabled ? null : keycloak,
-      authenticated: disabled ? false : authenticated,
-      failed: disabled ? false : timedOut
-
-     }}>
+    <KeycloakContext value={value}>
       {children}
     </KeycloakContext>
   );

--- a/src/lib/keycloak-provider/KeycloakProvider.tsx
+++ b/src/lib/keycloak-provider/KeycloakProvider.tsx
@@ -113,6 +113,11 @@ export const KeycloakProvider = ({
     } else if (initState === 'failed') {
       setAuthenticated(false);
       onInitError();
+    } else {
+      // Still in flight. `status` can be a stale 'ready' here — this provider was
+      // mounted with `disabled` true and has just been re-enabled — and leaving it
+      // would report a settled anonymous session while init is actually running.
+      setStatus('initializing');
     }
 
     // Backstop for an init that never settles either way. The failure path is

--- a/src/lib/keycloak-provider/README.md
+++ b/src/lib/keycloak-provider/README.md
@@ -1,5 +1,9 @@
 ### React Keycloak Provider
 
+> **Changed in 2.2.0**: `children` render immediately — the provider no longer replaces
+> your whole app with `loader` while `keycloak.init()` is in flight, and it settles as soon
+> as init rejects instead of waiting out `timeout`. Gate on the new `initializing` value
+> where you actually need the session. See the root `README.md` for the full note.
 
 ##### usage
 ```tsx
@@ -35,17 +39,18 @@ root.render(
 ```tsx
 
 // App.tsx
-import { useKeycloak } from './lib/keycloak-provider/useKeycloakContext';
+import { useKeycloak } from './lib/keycloak-provider/KeycloakProvider';
 import Button from '@mui/material/Button';
 
 const AppBar = ()=> {
-    const {keycloak, authenticated} = useKeycloak();
+    const {keycloak, authenticated, initializing, loader} = useKeycloak();
 
-
+    // "not known yet" is distinct from "anonymous"
+    if (initializing) return <>{loader}</>;
 
     return (
         <div> 
-            {keycloak & authenticated? 
+            {keycloak && authenticated? 
                 <Button onClick={keycloak.logout} label="Logout" /> :  
                 <Button onClick={keycloak.login} label="Login" />
             } 

--- a/src/lib/keycloak-provider/keycloakService.ts
+++ b/src/lib/keycloak-provider/keycloakService.ts
@@ -28,6 +28,7 @@ export class KeycloakService {
 
   private authenticated = false;
   private initState: KeycloakInitState = 'initializing';
+  private readyAnnounced = false;
 
   private constructor(props: KeycloakServiceProps) {
     this.initKeycloak(props);
@@ -56,16 +57,18 @@ export class KeycloakService {
     this.keycloak.onReady = (authenticated?: boolean) => {
       this.authenticated = !!authenticated;
       this.initState = 'ready';
-      this.readyListeners.forEach(listener => listener());
+      this.announceReady();
     };
 
     this.keycloak
       .init(initOptions ?? { onLoad: 'login-required' })
       .then((authenticated: boolean) => {
         this.authenticated = authenticated;
-        // onReady fires just before init() resolves, so this is normally a no-op —
-        // it also settles adapters that never call onReady at all.
+        // onReady fires just before init() resolves, so this is normally a no-op.
+        // It is what settles an adapter that resolves without calling onReady at
+        // all: announceReady is idempotent, so subscribers are notified exactly once.
         this.initState = 'ready';
+        this.announceReady();
         if (authenticated) {
           this.authSuccessListeners.forEach(listener => listener());
         } else {
@@ -82,6 +85,13 @@ export class KeycloakService {
         this.initErrorListeners.forEach(listener => listener());
         this.authErrorListeners.forEach(listener => listener());
       });
+  }
+
+  /** Fires 'keycloak-ready' at most once, whichever init path gets there first. */
+  private announceReady(): void {
+    if (this.readyAnnounced) return;
+    this.readyAnnounced = true;
+    this.readyListeners.forEach(listener => listener());
   }
 
   public getKeycloakInstance(): Keycloak | null {

--- a/src/lib/keycloak-provider/keycloakService.ts
+++ b/src/lib/keycloak-provider/keycloakService.ts
@@ -1,12 +1,21 @@
 import Keycloak from 'keycloak-js';
+import type { KeycloakConfig, KeycloakInitOptions } from 'keycloak-js';
 
 interface KeycloakServiceProps {
   // ✅ config is now required
-  config: string | Keycloak.KeycloakConfig;
-  initOptions?: Keycloak.KeycloakInitOptions;
+  config: string | KeycloakConfig;
+  initOptions?: KeycloakInitOptions;
 }
 
-type KeycloakEvent = 'auth-success' | 'auth-error' | 'keycloak-ready';
+/**
+ * Where `keycloak.init()` currently stands.
+ *
+ * `initializing` is the only unsettled value: both `ready` and `failed` mean the
+ * adapter has finished and the answer will not change without a page load.
+ */
+export type KeycloakInitState = 'initializing' | 'ready' | 'failed';
+
+type KeycloakEvent = 'auth-success' | 'auth-error' | 'keycloak-ready' | 'init-error';
 
 export class KeycloakService {
   private static instance: KeycloakService | null = null;
@@ -15,8 +24,10 @@ export class KeycloakService {
   private authSuccessListeners: Array<() => void> = [];
   private authErrorListeners: Array<() => void> = [];
   private readyListeners: Array<() => void> = [];
+  private initErrorListeners: Array<() => void> = [];
 
   private authenticated = false;
+  private initState: KeycloakInitState = 'initializing';
 
   private constructor(props: KeycloakServiceProps) {
     this.initKeycloak(props);
@@ -29,6 +40,11 @@ export class KeycloakService {
     return KeycloakService.instance;
   }
 
+  /** Drops the singleton so the next `getInstance` re-inits. For tests only. */
+  public static resetInstance(): void {
+    KeycloakService.instance = null;
+  }
+
   private initKeycloak(props: KeycloakServiceProps) {
     const { config, initOptions } = props;
 
@@ -37,8 +53,9 @@ export class KeycloakService {
       this.keycloak = new Keycloak(config);
     }
 
-    this.keycloak.onReady = (authenticated: boolean) => {
-      this.authenticated = authenticated;
+    this.keycloak.onReady = (authenticated?: boolean) => {
+      this.authenticated = !!authenticated;
+      this.initState = 'ready';
       this.readyListeners.forEach(listener => listener());
     };
 
@@ -46,6 +63,9 @@ export class KeycloakService {
       .init(initOptions ?? { onLoad: 'login-required' })
       .then((authenticated: boolean) => {
         this.authenticated = authenticated;
+        // onReady fires just before init() resolves, so this is normally a no-op —
+        // it also settles adapters that never call onReady at all.
+        this.initState = 'ready';
         if (authenticated) {
           this.authSuccessListeners.forEach(listener => listener());
         } else {
@@ -53,7 +73,13 @@ export class KeycloakService {
         }
       })
       .catch((error) => {
+        // init() rejects on an unreachable server, and on any browser that blocks
+        // the third-party-cookie probe. That is a settled outcome, not a hang:
+        // notify so the provider can stop waiting instead of burning its timeout.
         console.error('Keycloak initialization error:', error);
+        this.authenticated = false;
+        this.initState = 'failed';
+        this.initErrorListeners.forEach(listener => listener());
         this.authErrorListeners.forEach(listener => listener());
       });
   }
@@ -62,29 +88,38 @@ export class KeycloakService {
     return this.keycloak;
   }
 
-  public on(event: KeycloakEvent, listener: () => void): void {
+  /**
+   * The current init state. A subscriber that registers after init already settled
+   * never receives the event, so it has to read the state it missed.
+   */
+  public getInitState(): KeycloakInitState {
+    return this.initState;
+  }
+
+  public isAuthenticated(): boolean {
+    return this.authenticated;
+  }
+
+  private listenersFor(event: KeycloakEvent): Array<() => void> {
     switch (event) {
       case 'auth-success':
-        this.authSuccessListeners.push(listener);
-        break;
+        return this.authSuccessListeners;
       case 'auth-error':
-        this.authErrorListeners.push(listener);
-        break;
+        return this.authErrorListeners;
+      case 'init-error':
+        return this.initErrorListeners;
       case 'keycloak-ready':
-        this.readyListeners.push(listener);
-        break;
+        return this.readyListeners;
     }
+  }
+
+  public on(event: KeycloakEvent, listener: () => void): void {
+    this.listenersFor(event).push(listener);
   }
 
   // ✅ New .off method for cleanup
   public off(event: KeycloakEvent, listener: () => void): void {
-    const list =
-      event === 'auth-success'
-        ? this.authSuccessListeners
-        : event === 'auth-error'
-        ? this.authErrorListeners
-        : this.readyListeners;
-
+    const list = this.listenersFor(event);
     const index = list.indexOf(listener);
     if (index !== -1) list.splice(index, 1);
   }


### PR DESCRIPTION
Fixes [RKP-1](https://coolapp-dev.atlassian.net/browse/RKP-1) — KeycloakProvider blocks app render on init and never settles on failure.

`keycloak.init()` awaits a third-party-cookie probe before it calls `onReady`, and **rejects** whenever that probe cannot complete — an auth server on a different site, or Safari/Firefox/restricted-mode Chrome. The service logged that rejection and fired `auth-error`, but never marked itself ready, so the provider waited out its full `timeout` and only then rendered through the `timedOut` fallback. The timeout was doing the work of the failure path. Meanwhile the provider returned `loader` *instead of* `children` for that whole window, so nothing rendered — public routes included.

## What changed

**`keycloakService.ts`**
- Tracks a settled `initState` (`initializing` / `ready` / `failed`) and fires a new, distinct **`init-error`** event when `init()` rejects. A rejection is no longer conflated with an ordinary anonymous `check-sso`, which also fires `auth-error`.
- Adds `getInitState()` / `isAuthenticated()`. The service is a page-lifetime singleton, so a provider can mount *after* init already settled and never receive the event — it now reads the state it missed instead of hanging until the backstop.

**`KeycloakProvider.tsx`**
- **Always renders `children`.** Consumers gate only what depends on identity.
- Settles on `init-error` immediately; `timeout` is now purely a backstop for an init that never settles either way.
- Adds **`initializing`** to the context. It is deliberately not a synonym for `!authenticated`: it means "we don't know yet whether there is a session", so a consumer dispatching on role can avoid rendering an anonymous tree and remounting it when the token lands.
- The init effect reads `config` / `initOptions` / `timeout` through a ref and depends on `[disabled]` alone, so the inline object literals both READMEs show no longer re-run it on every render (tearing down all listeners and arming a fresh timeout each time). Re-running was pointless regardless — the singleton ignores config after the first init.
- The context value is `useMemo`'d.

**`loader` prop** — kept and surfaced through the context, so a consumer that wants the old behaviour writes `if (initializing) return <>{loader}</>;` wherever it wants the gate. It is no longer applied globally. This is an interpretation of required change 5; see the task-memory comment on the issue if you would rather it were accepted-and-ignored or deprecated.

**`ci/tests/App.tsx`** — not optional. It is packed and installed by the E2E workflow, so it is a genuine consumer: with the global gate gone it renders its `Login` link before `keycloak` exists, and `tests.py` clicks that link. It now gates its auth controls on `initializing`.

**Docs** — both READMEs carry the behaviour-change note, a context field table, and the one-line recipe for restoring the old global gate. CLAUDE.md's architecture and quirks sections are brought in line (the `keycloak & authenticated` bitwise typo in the package README is fixed at the same time).

## Tests

First test suite in `src/` — the repo had Jest, `setupTests.ts` and `@testing-library` configured but no test files. `src/lib/keycloak-provider/KeycloakProvider.test.tsx` mocks `keycloak-js` and drives `init()` per case: children render during init; a rejection settles as `failed` without waiting out a 100s timeout; both success paths; anonymous `check-sso` is not a failure; the timeout backstop still works; the effect runs once per mount with inline `initOptions`; a provider mounted after init settled picks up the settled state; `disabled` never constructs Keycloak.

10 passed individually and as a suite. `tsc --noEmit` and `rollup -c` both clean; the emitted `build/index.d.ts` carries `initializing` and `loader`.

## Note for the merger

Needs the **`minor`** label — the acceptance criteria asks for 2.2.0 and `semver-check.yml` blocks the merge without it. `package.json` `version` is left for release-it.
