### PR TITLE
RKP-4: Adopt a cut-release cycle: release/X.Y.Z branches, main as the publish target

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -1,0 +1,195 @@
+# Cuts a release branch — SDLC Phase 2 (Feature Freeze & Release Cut).
+#
+# Manual dispatch from `development`: resolves the next semantic version from
+# the latest stable tag plus the intended bump, branches `release/X.Y.Z` off
+# `development`, and opens a DRAFT PR into `main` carrying the bump label.
+#
+# The label on that PR is what `release.yml` reads to pick release-it's
+# --increment when the PR is merged, so the branch name and the version that
+# actually ships stay in agreement. Relabel the PR before merging only if you
+# also mean to change the version (see docs/RELEASING.md).
+#
+# Humans QA on the branch by opening fix PRs back into `release/X.Y.Z`, then
+# mark the draft PR ready and merge it. `release.yml` takes over on that merge.
+#
+# Prereq: the repo setting "Allow GitHub Actions to create and approve pull
+# requests" must be ON for `gh pr create --draft` to succeed.
+name: Cut release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: Intended version bump, applied to the latest stable tag.
+        type: choice
+        options:
+          - minor
+          - major
+          - patch
+        default: minor
+        required: true
+      version:
+        description: Explicit version override, e.g. 2.4.0. Leave blank to compute it from the latest tag. Must be reachable from that tag by one of major/minor/patch.
+        type: string
+        required: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  cut:
+    name: Cut release/X.Y.Z from development
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: development
+          fetch-depth: 0
+
+      # Tags in this repo are bare X.Y.Z, not vX.Y.Z — release-it's default
+      # git.tagName is "${version}" and the "release-it" block in package.json
+      # does not override it. A leading v is tolerated when reading a tag, but
+      # never produced.
+      - name: Resolve next version
+        id: resolve
+        env:
+          INPUT_BUMP: ${{ inputs.bump }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+
+          latest=$(git tag --list \
+                   | sed -E 's/^v//' \
+                   | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+                   | sort -t. -k1,1n -k2,2n -k3,3n \
+                   | tail -1 || true)
+          if [ -z "${latest}" ]; then
+            echo "::notice::No stable tag found; treating the latest release as 0.0.0."
+            latest="0.0.0"
+          fi
+
+          major_part="${latest%%.*}"
+          rest="${latest#*.}"
+          minor_part="${rest%%.*}"
+          patch_part="${rest##*.}"
+
+          next_major="$((major_part + 1)).0.0"
+          next_minor="${major_part}.$((minor_part + 1)).0"
+          next_patch="${major_part}.${minor_part}.$((patch_part + 1))"
+
+          if [ -n "${INPUT_VERSION}" ]; then
+            V="${INPUT_VERSION#v}"
+            # The override must still be one of the three reachable bumps:
+            # release.yml computes the published version from the LABEL, so a
+            # version the label cannot produce would make the branch name lie
+            # about what eventually ships.
+            case "${V}" in
+              "${next_major}") BUMP=major ;;
+              "${next_minor}") BUMP=minor ;;
+              "${next_patch}") BUMP=patch ;;
+              *)
+                echo "::error::version '${INPUT_VERSION}' is not reachable from the latest tag ${latest}. Reachable: ${next_major} (major), ${next_minor} (minor), ${next_patch} (patch)."
+                exit 1
+                ;;
+            esac
+            echo "Override ${V} accepted; it is the ${BUMP} bump of ${latest}."
+          else
+            BUMP="${INPUT_BUMP}"
+            case "${BUMP}" in
+              major) V="${next_major}" ;;
+              minor) V="${next_minor}" ;;
+              patch) V="${next_patch}" ;;
+              *) echo "::error::unknown bump '${BUMP}'"; exit 1 ;;
+            esac
+            echo "Latest stable tag ${latest} + ${BUMP} -> ${V}"
+          fi
+
+          echo "version=${V}" >> "$GITHUB_OUTPUT"
+          echo "bump=${BUMP}" >> "$GITHUB_OUTPUT"
+
+      - name: Create release/${{ steps.resolve.outputs.version }}
+        id: create
+        env:
+          V: ${{ steps.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+          branch="release/${V}"
+
+          if git ls-remote --heads origin "${branch}" | grep -q .; then
+            echo "::error::Branch ${branch} already exists on origin. Finish or delete that release before cutting it again (git push origin --delete ${branch}), or pass a different version."
+            exit 1
+          fi
+          if git ls-remote --tags origin "refs/tags/${V}" | grep -q .; then
+            echo "::error::Tag ${V} already exists on origin — that version has already shipped. Pick a higher version."
+            exit 1
+          fi
+
+          # An empty release PR cannot be merged, so fail here with a clear
+          # message instead of at `gh pr create`.
+          ahead=$(git rev-list --count origin/main..origin/development)
+          if [ "${ahead}" -eq 0 ]; then
+            echo "::error::development has no commits beyond main — there is nothing to release."
+            exit 1
+          fi
+          echo "development is ${ahead} commit(s) ahead of main."
+
+          git checkout -b "${branch}" origin/development
+          git push -u origin "${branch}"
+          echo "::notice::Created ${branch} from development"
+          echo "branch=${branch}" >> "$GITHUB_OUTPUT"
+
+      - name: Open draft PR into main
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          V: ${{ steps.resolve.outputs.version }}
+          BUMP: ${{ steps.resolve.outputs.bump }}
+          BRANCH: ${{ steps.create.outputs.branch }}
+        run: |
+          set -euo pipefail
+          # Unquoted heredoc so ${V} expands; deliberately backtick-free so
+          # nothing in the body gets shell-interpreted.
+          body=$(cat <<EOF
+          Release cut from development — SDLC Phase 2.
+
+          1. QA runs against ${BRANCH}. Fix bugs as PRs into that branch
+             (fix/short-description); never merge new features here.
+          2. When green, mark this draft PR ready and merge it into main.
+          3. release.yml then runs release-it on main: it bumps package.json to
+             ${V}, tags it, publishes the GitHub Release and the npm package,
+             and back-merges main into development.
+
+          The ${BUMP} label is what release.yml reads to compute the version.
+          Changing it changes the published version, and this branch name would
+          then no longer match what ships.
+
+          Diff: development...${BRANCH}
+
+          ---
+          *Automated release cut via GitHub Actions* 🚀
+          EOF
+          )
+          url=$(gh pr create \
+            --base main --head "${BRANCH}" --draft \
+            --title "Release ${V}" \
+            --label "${BUMP}" \
+            --body "${body}")
+          echo "draft_pr=${url}" >> "$GITHUB_OUTPUT"
+          echo "${url}"
+
+      - name: Job summary
+        env:
+          V: ${{ steps.resolve.outputs.version }}
+          BUMP: ${{ steps.resolve.outputs.bump }}
+          BRANCH: ${{ steps.create.outputs.branch }}
+          DRAFT_PR: ${{ steps.pr.outputs.draft_pr }}
+        run: |
+          {
+            echo "## Cut release ${V}"
+            echo ""
+            echo "- branch: \`${BRANCH}\` (cut from \`development\`)"
+            echo "- draft PR (labeled \`${BUMP}\`): ${DRAFT_PR}"
+            echo ""
+            echo "Next: QA on this branch, then merge the draft PR into \`main\` — \`release.yml\` does the rest."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -14,6 +14,13 @@
 #
 # Prereq: the repo setting "Allow GitHub Actions to create and approve pull
 # requests" must be ON for `gh pr create --draft` to succeed.
+#
+# Why this workflow dispatches tests.yml explicitly at the end: GitHub does not
+# start workflow runs for events triggered by GITHUB_TOKEN (its recursion
+# guard), so the `git push` that creates release/X.Y.Z below does NOT fire
+# tests.yml's `release/*` push trigger. Without the explicit dispatch, a release
+# with no QA fixes would publish a tree the E2E suite never ran against.
+# workflow_dispatch is the documented exception to that guard.
 name: Cut release
 
 on:
@@ -36,6 +43,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write   # dispatch tests.yml onto the new release branch
 
 jobs:
   cut:
@@ -178,18 +186,44 @@ jobs:
           echo "draft_pr=${url}" >> "$GITHUB_OUTPUT"
           echo "${url}"
 
+      # The push above cannot trigger tests.yml (GITHUB_TOKEN recursion guard —
+      # see the header), so start the E2E run explicitly. Non-fatal: the branch
+      # and the draft PR already exist at this point, and failing the job here
+      # would leave them behind with a red run that suggests the cut itself
+      # broke. A warning plus the manual command is the honest outcome.
+      - name: Run the E2E suite against the release branch
+        id: e2e
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.create.outputs.branch }}
+        run: |
+          set -uo pipefail
+          if gh workflow run tests.yml --ref "${BRANCH}"; then
+            echo "::notice::Dispatched tests.yml against ${BRANCH}."
+            echo "dispatched=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::Could not dispatch tests.yml against ${BRANCH}. QA must start it by hand: gh workflow run tests.yml --ref ${BRANCH}"
+            echo "dispatched=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Job summary
         env:
           V: ${{ steps.resolve.outputs.version }}
           BUMP: ${{ steps.resolve.outputs.bump }}
           BRANCH: ${{ steps.create.outputs.branch }}
           DRAFT_PR: ${{ steps.pr.outputs.draft_pr }}
+          E2E: ${{ steps.e2e.outputs.dispatched }}
         run: |
           {
             echo "## Cut release ${V}"
             echo ""
             echo "- branch: \`${BRANCH}\` (cut from \`development\`)"
             echo "- draft PR (labeled \`${BUMP}\`): ${DRAFT_PR}"
+            if [ "${E2E}" = "true" ]; then
+              echo "- E2E suite: dispatched against \`${BRANCH}\`"
+            else
+              echo "- E2E suite: **not started** — run \`gh workflow run tests.yml --ref ${BRANCH}\`"
+            fi
             echo ""
             echo "Next: QA on this branch, then merge the draft PR into \`main\` — \`release.yml\` does the rest."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,53 +1,84 @@
-# For more information see: https://github.com/actions/create-release
+# Production release — fires when a PR is MERGED into `main` from EITHER a
+# release/* OR a hotfix/* branch.
+#
+# This used to trigger on every feature/* PR merged into `development`, which
+# published a new npm version per merged PR. `development` is now the
+# integration branch and publishes nothing; a release is an explicit cut
+# (cut-release.yml) that is QA'd on its branch and shipped by merging into
+# `main`. See docs/RELEASING.md and docs/SDLC.md.
+#
+# The only difference between the two paths is the version bump:
+#   - release/* : label-driven (major/patch, else the MINOR default). The label
+#     is put on the PR by cut-release.yml and matches the branch name.
+#   - hotfix/*  : always a forced PATCH bump.
+# Everything downstream (build, release-it tag + GitHub Release + npm publish,
+# back-merge into development) is shared.
+#
+# A feature PR merged straight into main does NOT trigger a release (the job
+# `if:` guard requires a release/* or hotfix/* head ref).
 permissions:
   contents: write
   pages: write
-  id-token: write
-
-# on:
-#   push:
-#     # Sequence of patterns matched against refs/tags
-#     tags:
-#       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+  id-token: write        # npm trusted publishing (OIDC)
+  pull-requests: write   # open the sync-back PR if the back-merge conflicts
 
 on:
   pull_request:
     types:
       - closed
     branches:
-      - 'development'
+      - 'main'
 
 name: release
 
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   release:
-    if: github.event.pull_request.merged == true && (startsWith(github.event.pull_request.head.ref, 'feature/') || startsWith(github.event.pull_request.head.ref, 'hotfix/'))
+    if: >
+      github.event.pull_request.merged == true &&
+      (
+        startsWith(github.event.pull_request.head.ref, 'release/') ||
+        startsWith(github.event.pull_request.head.ref, 'hotfix/')
+      )
     name: Create Release
     runs-on: ubuntu-latest
-    steps:
-      - name: Get the pull request labels
-        id: labels
-        run: echo "labels=$(jq -r '.pull_request.labels[].name' $GITHUB_EVENT_PATH | tr '\n' ',')" >> $GITHUB_ENV
+    outputs:
+      version: ${{ steps.released.outputs.version }}
 
+    steps:
+      # hotfix/* is always patch; release/* is label-driven (major/patch, else
+      # the minor default). Labels are read through env rather than inlined
+      # into the script.
       - name: Determine the release type
         id: release_type
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
         run: |
-          labels=${{ env.labels }}
-          if [[ "$labels" == *"major"* ]]; then
+          set -euo pipefail
+          if [[ "$HEAD_REF" == hotfix/* ]]; then
+            echo "Hotfix branch -> forced PATCH bump."
+            echo "release_type=patch" >> $GITHUB_ENV
+          elif [[ "$LABELS" == *"major"* ]]; then
             echo "release_type=major" >> $GITHUB_ENV
-          elif [[ "$labels" == *"minor"* ]]; then
-            echo "release_type=minor" >> $GITHUB_ENV
-          elif [[ "$labels" == *"patch"* ]]; then
+          elif [[ "$LABELS" == *"patch"* ]]; then
             echo "release_type=patch" >> $GITHUB_ENV
           else
-            echo "No valid release label found."
-            exit 1
+            echo "Release branch -> MINOR default (labels: '$LABELS')."
+            echo "release_type=minor" >> $GITHUB_ENV
           fi
 
-      - name: Checkout code
+      # Check out main itself, not the PR merge ref: release-it commits the
+      # version bump and pushes the tag, so HEAD has to be the branch.
+      - name: Checkout main (full history + tags)
         uses: actions/checkout@v6
         with:
+          ref: main
           fetch-depth: 0
+
       - name: git config
         run: |
           git config user.name "${GITHUB_ACTOR}"
@@ -75,38 +106,80 @@ jobs:
       #   run: yarn test --ci
 
 
-
-
       - name: Build package
         run: yarn build
 
       - name: Release-it
-        run: | # # -i  ${{ env.release_type }}
-          yarn release --ci  --increment=$release_type
+        run: | # bumps package.json, tags, GitHub Release, npm publish
+          yarn release --ci --increment=$release_type
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
-      
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-#      - id: deploy-storybook
-#        uses: bitovi/github-actions-storybook-to-github-pages@v1.0.3
-#        with:
-#          install_command: yarn install
-#          build_command: yarn build-storybook
-#          path: storybook-static
-#        env:
-#          GH_TOKEN: ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}
+      # The published version, read back from the file release-it just bumped.
+      # Tags in this repo are bare X.Y.Z (release-it's default git.tagName),
+      # so this doubles as the tag name.
+      - name: Record the released version
+        id: released
+        run: |
+          set -euo pipefail
+          version=$(jq --raw-output .version package.json)
+          echo "Released ${version}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
 
-      # - name: Create Release
-      #   id: create_release
-      #   uses: actions/create-release@v1
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-      #   with:
-      #     tag_name: ${{ github.ref }}
-      #     release_name: Release ${{ github.ref }}
-      #     body: |
-      #       Changes in this Release
-      #       - First Change
-      #       - Second Change
-      #     draft: false
-      #     prerelease: false
+  sync_to_development:
+    needs: [release]
+    name: Sync main back to development
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main (full history)
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: git config
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
+      # One sync mechanism for BOTH release/* and hotfix/*: attempt a direct
+      # back-merge of main -> development; only if that fails do we open a sync
+      # PR for a human to resolve — never a force-push. A push rejection
+      # (branch protection, a race) takes the same fallback as a conflict.
+      - name: Back-merge main into development
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.release.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          open_sync_pr() {
+            reason="$1"
+            sync_branch="sync/main-to-dev-${VERSION}"
+            git checkout -B "${sync_branch}" origin/main
+            git push -u origin "${sync_branch}"
+            body=$(cat <<EOF
+          Auto-opened by release.yml — the back-merge of main into development
+          after ${VERSION} could not be completed automatically (${reason}) and
+          needs a human. development must carry the release/hotfix changes, or
+          the next release cut will revert them.
+          EOF
+          )
+            url=$(gh pr create --base development --head "${sync_branch}" \
+              --title "[SYNC] Merge ${VERSION} from main back to development" \
+              --body "${body}")
+            echo "::warning::Back-merge needs a human (${reason}); opened sync PR: ${url}"
+          }
+
+          git fetch origin main development
+          git checkout -B development origin/development
+          if git merge --no-ff origin/main -m "[CHORE] sync main into development after ${VERSION}"; then
+            if git push origin development; then
+              echo "::notice::Synced main -> development after ${VERSION}."
+            else
+              open_sync_pr "push to development was rejected"
+            fi
+          else
+            git merge --abort
+            open_sync_pr "merge conflict"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,7 +157,19 @@ jobs:
             reason="$1"
             sync_branch="sync/main-to-dev-${VERSION}"
             git checkout -B "${sync_branch}" origin/main
-            git push -u origin "${sync_branch}"
+            # A leftover branch from an earlier attempt at this same version
+            # would otherwise fail the push and take the job down after the
+            # release already shipped. The branch is a throwaway pointer at
+            # main, so re-pointing it is safe.
+            git push -u origin "${sync_branch}" \
+              || git push --force-with-lease origin "HEAD:${sync_branch}"
+            # Same reason: a PR may already be open for that branch.
+            url=$(gh pr list --head "${sync_branch}" --base development \
+                    --state open --json url --jq '.[0].url // empty')
+            if [ -n "${url}" ]; then
+              echo "::warning::Back-merge needs a human (${reason}); sync PR already open: ${url}"
+              return 0
+            fi
             body=$(cat <<EOF
           Auto-opened by release.yml — the back-merge of main into development
           after ${VERSION} could not be completed automatically (${reason}) and

--- a/.github/workflows/semver-check.yml
+++ b/.github/workflows/semver-check.yml
@@ -1,5 +1,13 @@
 name: Release type check
 
+# Guards the label that drives the version bump. Which check applies depends on
+# where the PR is going (see docs/SDLC.md):
+#   release/* -> main : no check. cut-release.yml already labeled the PR with
+#                       the bump its branch name was computed from.
+#   * -> main         : the hotfix path — requires the `patch` label, because
+#                       release.yml forces a patch bump there anyway.
+#   * -> development  : requires major/minor/patch, so the label is on the
+#                       commit history a later release cut will roll up.
 on:
   pull_request:
     types:
@@ -8,6 +16,7 @@ on:
       - synchronize
     branches:
       - 'development'
+      - 'main'
 
 
 jobs:
@@ -28,13 +37,37 @@ jobs:
 
       - name: Determine the release type # TODO: deal with multiple labels
         id: release_type
+        env:
+          LABELS: ${{ env.labels }}
+          TARGET_BRANCH: ${{ github.base_ref }}
+          SOURCE_BRANCH: ${{ github.head_ref }}
         run: |
-          labels=${{ env.labels }}
-          if [[ "$labels" == *"major"* ]]; then
+          set -euo pipefail
+
+          # Release PRs (release/* -> main): the bump label came from the cut.
+          if [[ "$TARGET_BRANCH" == "main" && "$SOURCE_BRANCH" == release/* ]]; then
+            echo "Release branch PR -> skipping semver label check (labeled at cut time)"
+            echo "release_type=release" >> $GITHUB_ENV
+            exit 0
+          fi
+
+          # Hotfix PRs (-> main, non-release source): only patch allowed.
+          if [[ "$TARGET_BRANCH" == "main" ]]; then
+            if [[ "$LABELS" == *"patch"* ]]; then
+              echo "release_type=patch" >> $GITHUB_ENV
+            else
+              echo "Hotfix PRs to main require a 'patch' label."
+              exit 1
+            fi
+            exit 0
+          fi
+
+          # Feature PRs (-> development): require major/minor/patch.
+          if [[ "$LABELS" == *"major"* ]]; then
             echo "release_type=major" >> $GITHUB_ENV
-          elif [[ "$labels" == *"minor"* ]]; then
+          elif [[ "$LABELS" == *"minor"* ]]; then
             echo "release_type=minor" >> $GITHUB_ENV
-          elif [[ "$labels" == *"patch"* ]]; then
+          elif [[ "$LABELS" == *"patch"* ]]; then
             echo "release_type=patch" >> $GITHUB_ENV
           else
             echo "No valid release label found."

--- a/.github/workflows/semver-check.yml
+++ b/.github/workflows/semver-check.yml
@@ -14,6 +14,13 @@ on:
       - edited
       - opened
       - synchronize
+      # Without these two, the fix for a failed run — adding the missing label —
+      # does not re-run the check: `edited` covers the title/body/base, not
+      # labels, and a manual re-run replays the ORIGINAL event payload, which
+      # still has no label on it. The gate would stay red until someone pushed
+      # an unrelated commit.
+      - labeled
+      - unlabeled
     branches:
       - 'development'
       - 'main'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - 'feature/*'
       - 'hotfix/*'
+      # QA during a release freeze happens on the release branch and on the
+      # fix/* branches merged into it, so both have to run the E2E suite.
+      - 'release/*'
+      - 'fix/*'
 
 
 env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,13 @@ on:
       # fix/* branches merged into it, so both have to run the E2E suite.
       - 'release/*'
       - 'fix/*'
+  # Lets QA re-run the suite against any ref without pushing an empty commit,
+  # and — the load-bearing reason — lets cut-release.yml start this suite on a
+  # freshly cut release branch. The push that creates that branch is made with
+  # GITHUB_TOKEN, which never triggers workflows; workflow_dispatch is the
+  # documented exception. Requires this file to be present on the default
+  # branch (development), which is where release branches are cut from.
+  workflow_dispatch:
 
 
 env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,7 @@ for the exact Chrome version pinned (`CHROME_VERSION` env var) if reproducing lo
 
 This is the most informative file for understanding "what does correct behavior
 look like end-to-end." On push to `feature/*`, `hotfix/*`, `release/*` or `fix/*`
-branches it:
+branches — or on a manual `workflow_dispatch` against any ref — it:
 1. Downloads/caches a pinned Chrome + chromedriver build.
 2. Loads/caches the pinned Keycloak Docker image.
 3. `yarn install`, bumps a `-rc` prerelease version, `yarn build`, `yarn pack`.
@@ -188,6 +188,11 @@ releasing**:
   `development`) resolves the next version from the latest tag plus the intended
   bump, creates `release/X.Y.Z`, and opens a **draft PR into `main`** labeled with
   that bump. QA happens on that branch; bugs are fixed via `fix/*` PRs into it.
+- **A workflow's own pushes never trigger other workflows** (GitHub's
+  `GITHUB_TOKEN` recursion guard). That is why `cut-release.yml` ends by
+  dispatching `tests.yml` at the new release branch rather than relying on
+  `tests.yml`'s `release/*` push trigger, and why the draft release PR carries no
+  `semver-check` run. Don't "simplify" either one away.
 - `release.yml` runs on a `release/*` **or** `hotfix/*` PR merged into `main`:
   builds, then `release-it` does version bump/tag/GitHub release/npm publish. The
   bump is label-driven for `release/*` (default `minor`) and forced `patch` for

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,8 +44,12 @@ ci/
   requirements.txt              # Python deps for ci/tests (selenium)
 .github/workflows/
   tests.yml                     # full E2E pipeline (see "CI / E2E flow" below)
-  release.yml                   # build + release-it + npm publish on merge to `development`
-  semver-check.yml              # enforces a major/minor/patch PR label before merge
+  cut-release.yml               # manual dispatch: cuts release/X.Y.Z off development, opens a draft PR into main
+  release.yml                   # build + release-it + npm publish on merge of release/* or hotfix/* into `main`
+  semver-check.yml              # enforces the PR label rules per target branch (see "Release process")
+docs/
+  RELEASING.md                  # the release/hotfix runbook
+  SDLC.md                       # branching & lifecycle policy
 rollup.config.js                # library build: CJS + ESM bundles, plus a separate .d.ts bundle pass
 tsconfig.json                   # noEmit: true — TS is used for type-checking only, rollup/babel does the JS emit
 package.json                    # main/module/types point at ./build/*, scripts below
@@ -140,7 +144,8 @@ for the exact Chrome version pinned (`CHROME_VERSION` env var) if reproducing lo
 ## CI / E2E flow (`.github/workflows/tests.yml`)
 
 This is the most informative file for understanding "what does correct behavior
-look like end-to-end." On push to `feature/*` or `hotfix/*` branches it:
+look like end-to-end." On push to `feature/*`, `hotfix/*`, `release/*` or `fix/*`
+branches it:
 1. Downloads/caches a pinned Chrome + chromedriver build.
 2. Loads/caches the pinned Keycloak Docker image.
 3. `yarn install`, bumps a `-rc` prerelease version, `yarn build`, `yarn pack`.
@@ -159,10 +164,10 @@ keep that in mind if asked to "speed up CI by testing source directly."
 
 **Why the workflow bumps to an `-rc.<run>.<attempt>` version before packing.**
 `yarn add <tarball>` caches by `name@version`, and setup-node's `cache: 'yarn'`
-restores that cache across runs. `release-it` only bumps the version on merge to
-`development`, so without the bump every feature-branch run packs *different*
-contents under the *same* version — and yarn installs whichever copy it cached
-first. The symptom is a demo-app build failing against stale `.d.ts`
+restores that cache across runs. `release-it` only bumps the version when a
+release ships (a `release/*` or `hotfix/*` merge into `main`), so without the
+bump every run between two releases packs *different* contents under the *same*
+version — and yarn installs whichever copy it cached first. The symptom is a demo-app build failing against stale `.d.ts`
 (e.g. `Property 'x' does not exist on type ...` for something the branch just
 added), which looks like a source bug and isn't. The `Setup demo app` step
 asserts the installed version equals the packed one, so a recurrence fails
@@ -171,12 +176,33 @@ version clean" — nothing is committed or tagged (`--no-git-tag-version`).
 
 ## Release process
 
-- Work happens on branches named `feature/*` or `hotfix/*`, PR'd into `development`.
-- `semver-check.yml` blocks merge unless the PR has a `major`, `minor`, or `patch` label.
-- `release.yml` runs on PR merge to `development`: builds, then `release-it`
-  bumps version/tag/GitHub release/npm publish per the chosen label.
-- Commit messages containing `--skip-ci` skip both the test and release-type-check workflows.
-- `main`/default branch in this repo is `development`, not `main`.
+Full detail in [`docs/RELEASING.md`](docs/RELEASING.md) (runbook) and
+[`docs/SDLC.md`](docs/SDLC.md) (branching policy). In short — **merging is not
+releasing**:
+
+- Feature work happens on `feature/*`, PR'd into `development`. `semver-check.yml`
+  requires a `major`/`minor`/`patch` label on those PRs. **Merging into
+  `development` publishes nothing and creates no tag** — it used to publish an npm
+  version per merged PR; that trigger has moved to `main`.
+- A release is cut explicitly: `cut-release.yml` (manual `workflow_dispatch` from
+  `development`) resolves the next version from the latest tag plus the intended
+  bump, creates `release/X.Y.Z`, and opens a **draft PR into `main`** labeled with
+  that bump. QA happens on that branch; bugs are fixed via `fix/*` PRs into it.
+- `release.yml` runs on a `release/*` **or** `hotfix/*` PR merged into `main`:
+  builds, then `release-it` does version bump/tag/GitHub release/npm publish. The
+  bump is label-driven for `release/*` (default `minor`) and forced `patch` for
+  `hotfix/*`. It then back-merges `main` into `development`, opening a
+  `sync/main-to-dev-X.Y.Z` PR if that merge conflicts or the push is rejected.
+- `semver-check.yml` also guards PRs into `main`: `release/*` PRs skip the label
+  check (already labeled at cut time), anything else targeting `main` (the hotfix
+  path) requires `patch`.
+- Tags are bare `X.Y.Z`, **not** `vX.Y.Z` — that is `release-it`'s default
+  `git.tagName` and every existing tag follows it. `cut-release.yml` does version
+  math on tag names, so don't introduce a prefix.
+- Commit messages containing `--skip-ci` skip both the test and release-type-check
+  workflows.
+- The repo's default branch is `development`. `main` is the publish target, not
+  the working branch.
 
 ## Known quirks / things to double-check before "fixing"
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,17 @@ const AppBar = ()=> {
 
 ```
 
+## Contributing & releases
+
+`development` is the default branch and the integration target; `main` is the
+publish target. Merging a `feature/*` PR into `development` **does not** publish
+anything to npm. A release is cut explicitly (`cut-release.yml`) onto a
+`release/X.Y.Z` branch, QA'd there, and published when that branch's PR is
+merged into `main`.
+
+- [docs/RELEASING.md](docs/RELEASING.md) — how to cut, QA and ship a release, and the hotfix path
+- [docs/SDLC.md](docs/SDLC.md) — branching strategy and versioning policy
+
 ## References
 - [Keycloak JavaScript adapter](https://www.keycloak.org/docs/latest/securing_apps/index.html#_javascript_adapter)
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,174 @@
+# Releasing
+
+The step-by-step runbook for cutting a release and shipping a hotfix of
+`react-keycloak-provider`. For the branching policy see [SDLC.md](SDLC.md).
+
+- Repo: <https://github.com/kantorv/react-keycloak-provider>
+- Actions: <https://github.com/kantorv/react-keycloak-provider/actions>
+- Releases: <https://github.com/kantorv/react-keycloak-provider/releases>
+- npm: <https://www.npmjs.com/package/react-keycloak-provider>
+
+---
+
+## TL;DR
+
+| You want to… | Do this |
+| :--- | :--- |
+| Ship what's on `development` | Run **`cut-release.yml`** → QA the `release/X.Y.Z` branch → merge its draft PR into `main`. `release.yml` bumps, tags, releases, publishes to npm, and syncs back. |
+| Choose the version | Pick the `bump` input when you cut (default `minor`), or pass an explicit `version`. The branch is named after the resulting version. |
+| Emergency fix to the published package | Branch `hotfix/<KEY>-slug` off `main`, PR into `main` labeled `patch`, merge. `release.yml` forces a patch bump and syncs back. |
+| Publish from `development` | You don't. `development` publishes nothing — that is the point of this cycle. |
+
+There is **no prerelease/RC channel** and no `-rc` npm dist-tag. Only a merged
+`release/*` or `hotfix/*` PR into `main` publishes.
+
+---
+
+## 1. Cut the release (SDLC Phase 2)
+
+### Trigger it
+
+**GitHub UI (recommended):** Actions → *Cut release* → **Run workflow** →
+branch `development` → pick the `bump` → **Run workflow**.
+
+**CLI:**
+```bash
+gh workflow run cut-release.yml --ref development -f bump=minor
+# or pin the version explicitly:
+gh workflow run cut-release.yml --ref development -f bump=minor -f version=2.2.0
+```
+
+### What it does
+
+- Reads the latest stable tag (bare `X.Y.Z`) and applies the `bump` to get the
+  next version. With `2.1.0` as the latest tag, `minor` → `2.2.0`.
+- Refuses to continue if `release/X.Y.Z` or the tag `X.Y.Z` already exists on
+  origin, or if `development` has no commits beyond `main`.
+- Creates `release/X.Y.Z` from `development` and pushes it.
+- Opens a **draft PR** `release/X.Y.Z → main`, titled *"Release X.Y.Z"*, labeled
+  with the bump.
+
+The `version` input is a safety valve, not a free-form field: it must be one of
+the three versions reachable from the latest tag (`major`/`minor`/`patch`), and
+the workflow derives the PR label from which one it is. That is what keeps the
+branch name and the version that eventually ships from disagreeing — the label,
+not the branch name, is what `release.yml` acts on.
+
+> **Prereq:** *Settings → Actions → "Allow GitHub Actions to create and approve
+> pull requests"* must be **ON**, or the draft PR cannot be created.
+
+---
+
+## 2. QA & hardening (SDLC Phase 3)
+
+QA runs against `release/X.Y.Z`. `tests.yml` runs the full Selenium/Keycloak
+E2E suite on every push to it, and to the `fix/*` branches below. Fix bugs **on
+the release branch**, never by merging new features:
+
+```bash
+git checkout release/X.Y.Z
+git checkout -b fix/short-description
+# ...fix, commit...
+git push origin fix/short-description
+# open a PR: fix/short-description -> release/X.Y.Z, then merge it
+```
+
+---
+
+## 3. Ship it (SDLC Phase 4)
+
+When QA is green:
+
+1. Open the draft PR (`release/X.Y.Z → main`) and click **Ready for review**.
+2. Check the bump label. It was set at cut time and matches the branch name —
+   changing it now changes the version that ships, and the branch name will no
+   longer match it.
+
+   | Label | Result | When |
+   | :--- | :--- | :--- |
+   | `major` | `2.1.0` → `3.0.0` | Breaking API changes |
+   | `minor` | `2.1.0` → `2.2.0` | New features (the default) |
+   | `patch` | `2.1.0` → `2.1.1` | Bug fixes only |
+   | (none)  | treated as `minor` | Default |
+
+3. Get approval and **merge** the PR into `main`.
+
+Merging fires **`release.yml`**, which for a `release/*` head ref:
+
+- Checks out `main`, installs, and runs `yarn build` (rollup → `build/`).
+- Runs `release-it --ci --increment=<label>`: bumps `package.json`, commits and
+  pushes it, creates the `X.Y.Z` tag, publishes the GitHub Release with
+  auto-generated notes, and publishes the package to npm.
+- Back-merges `main → development` (opens a sync PR only if that fails).
+
+### Verify
+
+- The [Releases page](https://github.com/kantorv/react-keycloak-provider/releases)
+  shows the new `X.Y.Z` tag and notes.
+- `npm view react-keycloak-provider version` reports the new version.
+- `development` received the `[CHORE] sync main into development after X.Y.Z`
+  commit — or a sync PR is waiting.
+
+---
+
+## 4. Hotfix
+
+For a critical bug in the published package that can't wait for the next
+release:
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b hotfix/ISSUE-KEY-short-description
+# ...fix, commit...
+git push origin hotfix/ISSUE-KEY-short-description
+```
+
+Open a PR **into `main`** and label it **`patch`** (`semver-check.yml` requires
+it). On merge, the **same `release.yml`** handles the `hotfix/*` head ref:
+
+- Forces a **patch** bump regardless of what else is on the PR.
+- Builds, bumps, tags, publishes the GitHub Release and the npm package.
+- Back-merges `main → development` with the same mechanism.
+
+The hotfix and release paths differ **only** in the bump kind; everything else
+is one shared workflow.
+
+---
+
+## 5. The sync-back mechanism
+
+Both paths use **one** mechanism to bring `main` back into `development`:
+
+1. `release.yml` attempts a direct `git merge --no-ff main → development` and
+   pushes it.
+2. If the merge **conflicts**, or the push is **rejected** (branch protection, a
+   race), it aborts — never force-pushes — pushes a `sync/main-to-dev-X.Y.Z`
+   branch, and opens a **sync PR** into `development` for a human to resolve.
+
+Resolve that PR promptly: until it lands, `development` is missing the version
+bump and any release-branch fixes, and the next cut would revert them.
+
+---
+
+## 6. Troubleshooting
+
+| Symptom | Fix |
+| :--- | :--- |
+| **`cut-release` failed: branch already exists** | A release is already in flight. Finish it, or delete the branch (`git push origin --delete release/X.Y.Z`). |
+| **`cut-release` failed: version not reachable from the latest tag** | The `version` input must be the major, minor, or patch bump of the latest tag. The error lists the three accepted values. |
+| **`cut-release` failed: nothing to release** | `development` has no commits beyond `main`. Nothing to ship. |
+| **`cut-release` failed: "Resource not accessible by integration"** | Enable *Allow GitHub Actions to create and approve pull requests* in the repo's Actions settings. |
+| **`release.yml` didn't trigger** | The PR must be **merged** (not just closed), must target `main`, and its head branch must start with `release/` or `hotfix/`. |
+| **Wrong version published** | The label on the release PR at merge time decides it, not the branch name. `hotfix/*` is always `patch`. |
+| **Back-merge conflict / rejected push** | Resolve the auto-opened `sync/main-to-dev-X.Y.Z` PR into `development`. |
+| **Semver check failed on a hotfix PR** | Add the `patch` label — non-release PRs into `main` require it. |
+| **npm publish failed on auth** | Publishing uses npm trusted publishing (OIDC): `release.yml` needs `id-token: write` and npm ≥ 11.5.1, which the *Update npm* step installs. |
+
+---
+
+## References
+
+- [SDLC.md](SDLC.md) — branching & lifecycle policy
+- [`release-it` config](../package.json) — the `"release-it"` block
+- [`CLAUDE.md`](../CLAUDE.md) — repo layout and CI notes

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -47,6 +47,13 @@ gh workflow run cut-release.yml --ref development -f bump=minor -f version=2.2.0
 - Creates `release/X.Y.Z` from `development` and pushes it.
 - Opens a **draft PR** `release/X.Y.Z → main`, titled *"Release X.Y.Z"*, labeled
   with the bump.
+- Dispatches `tests.yml` against the new branch, so the E2E suite runs on the
+  tree you are about to QA. This has to be an explicit dispatch: the push that
+  created the branch was made with `GITHUB_TOKEN`, and GitHub does not start
+  workflow runs for `GITHUB_TOKEN` events. If the dispatch fails, the job warns
+  rather than failing (the branch and PR already exist) and tells you to run
+  `gh workflow run tests.yml --ref release/X.Y.Z` yourself — check the run
+  summary.
 
 The `version` input is a safety valve, not a free-form field: it must be one of
 the three versions reachable from the latest tag (`major`/`minor`/`patch`), and
@@ -61,9 +68,16 @@ not the branch name, is what `release.yml` acts on.
 
 ## 2. QA & hardening (SDLC Phase 3)
 
-QA runs against `release/X.Y.Z`. `tests.yml` runs the full Selenium/Keycloak
-E2E suite on every push to it, and to the `fix/*` branches below. Fix bugs **on
-the release branch**, never by merging new features:
+QA runs against `release/X.Y.Z`. The full Selenium/Keycloak E2E suite covers the
+branch from three directions: the cut dispatches it once against the fresh
+branch, every human push to `release/X.Y.Z` or a `fix/*` branch triggers it, and
+you can start it against any ref yourself from **Actions → tests → Run
+workflow** (or `gh workflow run tests.yml --ref release/X.Y.Z`). Automated
+pushes are the gap to know about — anything pushed by a workflow's
+`GITHUB_TOKEN` does not trigger it, which is exactly why the cut dispatches the
+run explicitly.
+
+Fix bugs **on the release branch**, never by merging new features:
 
 ```bash
 git checkout release/X.Y.Z
@@ -164,6 +178,9 @@ bump and any release-branch fixes, and the next cut would revert them.
 | **Back-merge conflict / rejected push** | Resolve the auto-opened `sync/main-to-dev-X.Y.Z` PR into `development`. |
 | **Semver check failed on a hotfix PR** | Add the `patch` label — non-release PRs into `main` require it. |
 | **npm publish failed on auth** | Publishing uses npm trusted publishing (OIDC): `release.yml` needs `id-token: write` and npm ≥ 11.5.1, which the *Update npm* step installs. |
+| **No E2E run on the release branch** | The cut's dispatch failed (check the *Cut release* run summary). Start it manually: `gh workflow run tests.yml --ref release/X.Y.Z`. |
+| **`release.yml` failed pushing to `main`** | `release-it` commits the version bump and tag directly to `main`. If `main` is given branch protection that blocks direct pushes, it must allow the `github-actions` app (or the release will never complete). |
+| **No checks at all on the release PR** | Expected: the draft PR is created by `GITHUB_TOKEN`, so `pull_request` workflows — including `semver-check.yml` — do not run on it. Harmless today, since `release/* → main` skips the label check anyway. **Do not make "Check release label" a required status check on `main`**: a release PR could never satisfy it. |
 
 ---
 

--- a/docs/SDLC.md
+++ b/docs/SDLC.md
@@ -43,13 +43,17 @@ on its own branch, and merged into `main`.
 
 - Run **`cut-release.yml`** from the Actions UI on `development`. It resolves
   the next version `X.Y.Z` from the latest tag plus the intended bump, creates
-  `release/X.Y.Z`, and opens a **draft PR** into `main` labeled with that bump.
+  `release/X.Y.Z`, opens a **draft PR** into `main` labeled with that bump, and
+  starts the E2E suite against the new branch.
 - **No new features** go into the release branch.
 - `development` stays open for the next release's work.
 
 ### Phase 3 — QA & hardening
 
-- QA exercises `release/X.Y.Z`. `tests.yml` runs on pushes to it.
+- QA exercises `release/X.Y.Z`. The cut dispatches `tests.yml` against the new
+  branch, and every human push to it runs the suite again. (A push made by a
+  workflow's own `GITHUB_TOKEN` never triggers a run — hence the explicit
+  dispatch.)
 - Bugs are fixed on `fix/*` branches cut from the release branch and merged
   back into it — never by merging fresh features from `development`.
 

--- a/docs/SDLC.md
+++ b/docs/SDLC.md
@@ -1,0 +1,131 @@
+# Software Development Life Cycle (SDLC) & Branching Strategy
+
+The branching and lifecycle policy for `react-keycloak-provider`.
+
+**Audience:** human developers and autonomous AI/LLM coding assistants.
+
+**Core idea:** *merging is not releasing.* Work is integrated continuously on
+`development`, but nothing reaches npm until a release is explicitly cut, QA'd
+on its own branch, and merged into `main`.
+
+> **See also:** [RELEASING.md](RELEASING.md) — the step-by-step runbook for
+> cutting a release and shipping a hotfix.
+
+---
+
+## 1. Branch architecture
+
+| Branch pattern | Source | Merges to | Purpose |
+| :--- | :--- | :--- | :--- |
+| `main` | `release/*`, `hotfix/*` | `development` | The published state of the package. Tagged `X.Y.Z` by `release-it`; every tag here corresponds to one npm version. |
+| `development` | `main` | `release/*` | The default working branch and the integration target. Publishes **nothing**. |
+| `feature/ISSUE-KEY-slug` | `development` | `development` | New features and non-critical fixes. |
+| `release/X.Y.Z` | `development` | `main` | Temporary freeze branch for QA and release hardening. Cut by `cut-release.yml`, named after the version it will publish. |
+| `fix/short-description` | `release/X.Y.Z` | `release/X.Y.Z` | Bug fixes found by QA during a freeze. |
+| `hotfix/ISSUE-KEY-slug` | `main` | `main` & `development` | **Only** for critical bugs in the published package that cannot wait for the next release. |
+
+`main` is not the repository's default branch — `development` is. `main` is the
+*publish target*.
+
+---
+
+## 2. The lifecycle
+
+### Phase 1 — Active development
+
+- Branch `feature/ISSUE-KEY-slug` off `development`; PR back into `development`.
+- `semver-check.yml` requires a `major`/`minor`/`patch` label on the PR.
+- `tests.yml` runs the Selenium/Keycloak E2E suite on every push to the branch.
+- Merging publishes nothing and creates no tag. `development` simply accumulates
+  the changes that the next release will contain.
+
+### Phase 2 — Release cut (freeze)
+
+- Run **`cut-release.yml`** from the Actions UI on `development`. It resolves
+  the next version `X.Y.Z` from the latest tag plus the intended bump, creates
+  `release/X.Y.Z`, and opens a **draft PR** into `main` labeled with that bump.
+- **No new features** go into the release branch.
+- `development` stays open for the next release's work.
+
+### Phase 3 — QA & hardening
+
+- QA exercises `release/X.Y.Z`. `tests.yml` runs on pushes to it.
+- Bugs are fixed on `fix/*` branches cut from the release branch and merged
+  back into it — never by merging fresh features from `development`.
+
+### Phase 4 — Ship
+
+- The draft PR is marked ready and merged into `main`.
+- `release.yml` runs `release-it` once on `main`: it bumps `package.json`,
+  creates the `X.Y.Z` tag and the GitHub Release, and publishes to npm.
+- `main` is then back-merged into `development` automatically so the QA fixes
+  are not lost (a `sync/main-to-dev-X.Y.Z` PR is opened if it conflicts).
+- The `release/X.Y.Z` branch can be deleted.
+
+---
+
+## 3. Hotfixes
+
+For a critical bug in the *published* package that cannot wait for the next
+release. This path bypasses `development` entirely, so unreleased work is not
+dragged into production.
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b hotfix/ISSUE-KEY-short-description
+# ...fix, commit, push...
+```
+
+Open a PR **into `main`** labeled `patch` (`semver-check.yml` enforces the
+label). On merge, `release.yml` forces a **patch** bump regardless of any other
+label, publishes, and back-merges `main` into `development` — that last step is
+what stops the next release cut from reintroducing the bug.
+
+---
+
+## 4. Versioning
+
+[Semantic Versioning](https://semver.org/), tagged on `main` as bare `X.Y.Z`
+(no `v` prefix — that is `release-it`'s default `git.tagName`, and every
+existing tag in this repo follows it).
+
+- **Stable tags `X.Y.Z`** are created **only** by `release.yml`, on a `release/*`
+  or `hotfix/*` PR merged into `main`. The bump is:
+  - `release/*` — **label-driven**: `major`/`patch`, else the **minor** default.
+    `cut-release.yml` puts that label on the PR, derived from the same input it
+    used to name the branch.
+  - `hotfix/*` — always **patch**.
+- There is **no prerelease channel.** Nothing publishes to npm from
+  `development`, and no `-rc` npm dist-tag exists. The `-rc.<run>.<attempt>`
+  version that `tests.yml` builds is a local cache-busting device inside the CI
+  runner — it is never committed, tagged, or published (see `CLAUDE.md`).
+
+Commit messages play no part in version resolution: the label decides.
+
+| Bump | Example | When |
+| :--- | :--- | :--- |
+| `major` | `2.1.0` → `3.0.0` | Breaking changes to the public API in `src/index.ts` |
+| `minor` | `2.1.0` → `2.2.0` | Backward-compatible features — the release default |
+| `patch` | `2.1.0` → `2.1.1` | Bug fixes only; always the hotfix bump |
+
+Never hand-edit `version` in `package.json`; `release-it` owns it.
+
+---
+
+## 5. 🤖 LLM directives
+
+*Instructions for AI coding assistants reading this document:*
+
+1. **Branch naming:** `<type>/<ISSUE-KEY>-<kebab-case-description>` (e.g.
+   `feature/RKP-12-add-token-refresh`). `feature/*` is cut from `development`;
+   the only exception is an emergency `hotfix/*` cut from `main`.
+2. **Target branches:** default PR targets to `development`. Target `main` only
+   for an explicit hotfix, or for a `release/*` branch created by
+   `cut-release.yml`.
+3. **Versioning:** never edit `package.json`'s `version`, never create tags by
+   hand, and never add an npm publish step to a workflow that triggers on
+   `development`. The bump comes from the PR label; Conventional Commits are not
+   used for versioning. Prefix each commit with its Jira issue key.
+4. **Release cuts are a human action.** Do not run `cut-release.yml` on your own
+   initiative.


### PR DESCRIPTION
Adopts a cut-release cycle: `development` integrates, `release/X.Y.Z` is QA'd, and merging into `main` is what publishes.

Issue: https://coolapp-dev.atlassian.net/browse/RKP-4

## What changes

**Nothing publishes from `development` any more.** `release.yml` used to fire on every `feature/*` PR merged into `development`, so each merge cut a tag and pushed a version to npm. It now fires on a `release/*` or `hotfix/*` PR merged into **`main`**.

- **`cut-release.yml` (new)** — manual `workflow_dispatch` from `development`. Resolves the next version from the latest stable tag plus the `bump` input (default `minor`), refuses to continue if the branch or tag already exists on origin or if `development` has nothing beyond `main`, creates and pushes `release/X.Y.Z`, and opens a **draft PR into `main`** labeled with the bump.
- **`release.yml` (reworked)** — triggers on `pull_request: closed` into `main`, guarded on `merged == true` and a `release/`/`hotfix/` head ref. `hotfix/*` forces a **patch** bump; `release/*` is label-driven (`major`/`patch`, else the `minor` default). Checks out `main` itself (not the PR merge ref) with full history, keeps the existing OIDC/trusted-publishing handling, builds, then `release-it --ci --increment=<kind>`. A second job back-merges `main` into `development`, falling back to a `sync/main-to-dev-X.Y.Z` PR — never a force-push.
- **`semver-check.yml`** — now also runs on PRs into `main`: `release/* -> main` skips the label check (labeled at cut time), anything else targeting `main` requires `patch`, and PRs into `development` keep the `major`/`minor`/`patch` requirement.
- **`tests.yml`** — the E2E suite now also runs on `release/*` and `fix/*` pushes, so the freeze branch is actually exercised.
- **`docs/RELEASING.md`, `docs/SDLC.md` (new)**, plus `CLAUDE.md` and `README.md` updates so nothing still describes the old "merge to development publishes" behavior.

## Two design points worth reviewing

**The label, not the branch name, decides the published version.** That was the confirmed decision for `release.yml`, and it means a free-form `version` override could name a branch `release/2.9.0` while the label still published `2.2.0`. So `cut-release` accepts an explicit version only when it is one of the three versions reachable from the latest tag, and derives the PR label from which one it is. The alternative — having `release.yml` read the version off the branch name — would be a different contract than the one specified here.

**Tags in this repo are bare `X.Y.Z`, not `vX.Y.Z`** (release-it's default `git.tagName`; the `release-it` block in `package.json` doesn't override it, and all 15 existing tags follow it). The version math in `cut-release.yml` depends on that, tolerates a `v` prefix when reading a tag, and never produces one. It's now written down in `docs/SDLC.md` and `CLAUDE.md`.

## Testing

YAML-only changes can't be verified by running them, so beyond a parse:

1. All four workflows parse with PyYAML; every embedded `run:` script passes `bash -n` (33 steps).
2. The three decision steps were **extracted from the YAML and executed locally** with each step's env injected and `GITHUB_OUTPUT`/`GITHUB_ENV` pointed at temp files — 21 cases, all passing, run against this repo's real git tags:
   - `cut-release` version resolution: `2.1.0` + minor/major/patch -> `2.2.0`/`3.0.0`/`2.1.1`; a reachable override derives the right label (`3.0.0` -> `major`, `v2.1.1` -> `patch`); `2.9.0`, `not-a-version` and an unknown bump all exit non-zero.
   - `release.yml` bump kind: `hotfix/*` yields `patch` even when the PR carries a `major` label; `release/*` with no label yields `minor`.
   - `semver-check`: `release/* -> main` passes with no label; `hotfix -> main` fails without `patch`; `-> development` still fails with no label.
3. Confirmed the `major`/`minor`/`patch` labels exist in the repo, so `gh pr create --label` in `cut-release` will not fail.
4. Full Jest suite green (12/12) — no source files were touched.

**The first real cut is the live verification.** The workflow graph itself (dispatch inputs, the `main` triggers, `gh pr create --draft`) can only be exercised on GitHub. Note the prerequisite: *Settings -> Actions -> "Allow GitHub Actions to create and approve pull requests"* must be **ON**, or `cut-release` cannot open its draft PR.

Merging this PR into `development` publishes nothing — which is the change.
